### PR TITLE
get_token_from_hash的问题

### DIFF
--- a/lib/weibo_2/client.rb
+++ b/lib/weibo_2/client.rb
@@ -31,15 +31,11 @@ module WeiboOAuth2
     
     def get_token_from_hash(hash)
       access_token = hash.delete(:access_token) || hash.delete('access_token')
-      opts = {:expires_at => (hash.delete(:expires_at) || hash.delete('expires_at')),
-              :header_format => "OAuth2 %s",
-              :param_name => "access_token"}
-
-      @access_token = WeiboOAuth2::AccessToken.new(self, access_token, opts)
+      @access_token = WeiboOAuth2::AccessToken.new( self, access_token, hash.merge(:header_format => 'OAuth2 %s', :param_name => 'access_token') )
     end
     
     def authorized?
-      !!@access_token
+      @access_token && @access_token.validated?
     end
     
     def users


### PR DESCRIPTION
新浪那边传来的是`"expires"=>142582`，应该不需要单独取出`expires_at`，直接丢给`OAuth2::AccessToken`处理好了

另外，`authorized?`方法不单单要判断`@access_token`是否存在，还要判断`@access_token`是否有效
