### PR TITLE
Compatible with MultiJson 1.x

### DIFF
--- a/lib/weibo_2/api/v2/base.rb
+++ b/lib/weibo_2/api/v2/base.rb
@@ -17,7 +17,7 @@ module WeiboOAuth2
         end
         
         def hashie(response)
-          json_body = MultiJson.load(response.body)
+          json_body = MultiJson.decode(response.body)
           if json_body.is_a? Array
             Array.new(json_body.count){|i| Hashie::Mash.new(json_body[i])}
           else

--- a/weibo_2.gemspec
+++ b/weibo_2.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/weibo_2/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["simsicon"]
   gem.email         = ["simsicon@gmail.com"]
-  gem.description   = %q{WeioOAuth2 is a Ruby gem that provides a wrapper for interacting with sina weibo's v2 API, 
+  gem.description   = %q{WeioOAuth2 is a Ruby gem that provides a wrapper for interacting with sina weibo's v2 API,
                          which is currently the latest version. The output data format is Hashie::Mash}
   gem.summary       = "A oauth2 gem for weibo"
   gem.homepage      = "http://github.com/simsicon/weibo_2"
@@ -15,11 +15,11 @@ Gem::Specification.new do |gem|
   gem.name          = "weibo_2"
   gem.require_paths = ["lib"]
   gem.version       = WeiboOAuth2::Version
-  
+
   gem.add_development_dependency "rspec", "~> 2.6"
-  
+
   gem.add_runtime_dependency 'oauth2', "~> 0.9.1"
   gem.add_runtime_dependency 'hashie', "~> 2.0.4"
-  gem.add_runtime_dependency 'multi_json'  , "~> 1.7.2"
+  gem.add_runtime_dependency 'multi_json'  , "~> 1"
   gem.add_runtime_dependency 'rest-client', "~> 1.6.7"
 end


### PR DESCRIPTION
Simply use `MultiJson.decode` will allow us compatible with MultiJson 1.x, instead of lock to 1.7.2.
