### PR TITLE
Fix initialization issue with access_token

### DIFF
--- a/lib/weibo_2/config.rb
+++ b/lib/weibo_2/config.rb
@@ -6,7 +6,7 @@ module WeiboOAuth2
     end
     
     def self.api_key
-      @@api_key
+      @@api_key ||= nil
     end
     
     def self.api_secret=(val)
@@ -14,7 +14,7 @@ module WeiboOAuth2
     end
     
     def self.api_secret
-      @@api_secret
+      @@api_secret ||= nil
     end
     
     def self.redirect_uri=(val)
@@ -22,7 +22,7 @@ module WeiboOAuth2
     end
     
     def self.redirect_uri
-      @@redirect_uri
+      @@redirect_uri ||= nil
     end
 
   end


### PR DESCRIPTION
This resolves client initialization issue when specifying `access_token`
directly instead of giving `api_key` and `api_secret` to generate one. The
following line works now:

``` ruby
client = WeiboOAuth2::Client.from_hash(access_token: YOUR_TOKEN)
```
