### PR TITLE
Bump rest-client dependency

### DIFF
--- a/weibo_2.gemspec
+++ b/weibo_2.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'oauth2', "~> 0.9.1"
   gem.add_runtime_dependency 'hashie', "~> 2.0.4"
-  gem.add_runtime_dependency 'multi_json'  , "~> 1"
-  gem.add_runtime_dependency 'rest-client', "~> 1.7.3"
+  gem.add_runtime_dependency 'multi_json', "~> 1"
+  gem.add_runtime_dependency 'rest-client', "~> 1.8"
 end


### PR DESCRIPTION
Fix for #20.  Specs pass, but I don't have a Weibo account, so I can't test functionality.  This bump is needed to fix the security vulnerability in rest-client.  http://www.openwall.com/lists/oss-security/2015/03/24/3
